### PR TITLE
feat:(core) - Implement env vars to use "process.env"

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,9 @@
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
+declare var process: {
+  env: ProcessEnv;
+};
 
-interface ImportMetaEnv extends APIEndpoint {
-  readonly NODE_ENV: string;
+interface ProcessEnv extends APIEndpoint {
+  readonly NG_APP_ENV: string;
 }
 
 interface APIEndpoint {
@@ -13,3 +13,16 @@ interface APIEndpoint {
   readonly NG_APP_API_INT_FOOTBALL_RESULTS: string;
   readonly NG_APP_API_INT_FOOTBALL_SHOOTOUTS: string;
 }
+
+/*
+ ### use this setup when the "import.meta" jest error will be fixed ###
+ 
+ interface ImportMeta {
+   readonly env: ImportMetaEnv;
+ }
+ 
+ interface ImportMetaEnv extends APIEndpoint {
+   readonly NODE_ENV: string;
+ }
+  
+ */

--- a/src/environments/envinronment.ts
+++ b/src/environments/envinronment.ts
@@ -1,0 +1,14 @@
+export const environment = {
+  production: false,
+  api: {
+    baseUrl: process.env.NG_APP_API_BASE_URL,
+    endpoints: {
+      topics: process.env.NG_APP_API_ALL_TOPICS,
+      intFootball: {
+        goalscorers: process.env.NG_APP_API_INT_FOOTBALL_GOALSCORERS,
+        results: process.env.NG_APP_API_INT_FOOTBALL_RESULTS,
+        shootouts: process.env.NG_APP_API_INT_FOOTBALL_SHOOTOUTS,
+      },
+    },
+  },
+};

--- a/src/shared/services/http-service/http-service.service.spec.ts
+++ b/src/shared/services/http-service/http-service.service.spec.ts
@@ -1,12 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 
 import { HttpService } from './http-service.service';
+import { MockModule, MockService } from 'ng-mocks';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('HttpService', () => {
   let service: HttpService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [MockModule(HttpClientModule)],
+    });
     service = TestBed.inject(HttpService);
   });
 

--- a/src/shared/services/http-service/http-service.service.ts
+++ b/src/shared/services/http-service/http-service.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Topic } from '../../types';
 import { Observable, map } from 'rxjs';
+import { environment } from '../../../environments/envinronment';
 
 @Injectable({
   providedIn: 'root',
@@ -12,9 +13,7 @@ export class HttpService {
   public getTopics(): Observable<Topic[]> {
     return this.http
       .get<Topic[]>(
-        `${import.meta.env.NG_APP_API_BASE_URL}/${
-          import.meta.env.NG_APP_API_ALL_TOPICS
-        }`
+        `${environment.api.baseUrl}/${environment.api.endpoints.topics}`
       )
       .pipe(map((topics) => [...topics, ...topics])); // TODO: remove duplicate topics [they are just for scroll testing]
   }


### PR DESCRIPTION
# Description
- Changed `env.d.ts` in order to use `process.env` notation.
- Created environment file to store `env vars` and use them from there.

`NOTE`: The change for using `process.env` instead of `import.meta` was because `jest` throws the below error. Until a fix will be found for this, `process.env` notation will be used.

`ERROR`:
```
error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
```