### PR TITLE
feat:(core) - Increase prod build budgets and use primeflex css classes directly for reducing bundle size

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -24,7 +24,7 @@
         "build": {
           "builder": "@ngx-env/builder:application",
           "options": {
-            "outputPath": "dist/angular-client",
+            "outputPath": "dist",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],
@@ -54,13 +54,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "1mb",
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "4kb",
+                  "maximumError": "6kb"
                 }
               ],
               "outputHashing": "all"

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -2,7 +2,7 @@
   <ng-template pTemplate="start">
     <button
       [attr.aria-label]="'toolbar.sidebar' | translate"
-      class="toolbar__button p-link"
+      class="toolbar__button p-link flex flex-column justify-content-center align-items-center text-xs h-3rem w-3rem border-circle transition-all transition-duration-200"
     >
       <i class="pi pi-bars text-2xl"></i>
     </button>
@@ -12,7 +12,7 @@
       @for (action of toolbarActions; track $index) {
       <button
         (click)="action.callback()"
-        class="toolbar__button p-link"
+        class="toolbar__button p-link flex flex-column justify-content-center align-items-center text-xs h-3rem w-3rem border-circle transition-all transition-duration-200"
         data-test-name="toolbarAction"
       >
         <i [ngClass]="action.icon + ' text-2xl'"></i>
@@ -23,7 +23,7 @@
 
       <button
         (click)="toggleTheme()"
-        class="toolbar__button p-link"
+        class="toolbar__button p-link flex flex-column justify-content-center align-items-center text-xs h-3rem w-3rem border-circle transition-all transition-duration-200"
         data-test-name="toggleThemeAction"
       >
         <i
@@ -49,7 +49,7 @@
       <button
         [attr.aria-label]="'avatar.menu' | translate"
         (click)="menu.toggle($event)"
-        class="toolbar__button p-link"
+        class="toolbar__button p-link flex flex-column justify-content-center align-items-center text-xs h-3rem w-3rem border-circle transition-all transition-duration-200"
         data-test-name="toolbarAvatarImage"
       >
         @if (avatar.imagePath) {

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -1,5 +1,3 @@
-@import "primeflex/primeflex.scss";
-
 .toolbar {
   color: var(--toolbar-text-color);
   background: var(--toolbar-background);
@@ -17,10 +15,6 @@
 
   &__button {
     color: inherit;
-
-    @include styleclass(
-      "flex flex-column justify-content-center align-items-center text-xs h-3rem w-3rem border-circle transition-all transition-duration-200"
-    );
 
     &:hover,
     &:hover + span {


### PR DESCRIPTION
# Description
- Increased build budgets to not throw an  error at build time.
- Where possible, used `primeflex` CSS classes directly and removed the import of the whole style. Doing so, the CSS bundle will decrease.